### PR TITLE
Add patch for sscanf on libc

### DIFF
--- a/src/utils/patch_wasm.h
+++ b/src/utils/patch_wasm.h
@@ -25,4 +25,9 @@ int32_t __imported_wasi_snapshot_preview1_fd_write(int32_t, int32_t, int32_t, in
     assert(false);
     return -1;
 }
+
+int sscanf(const char *, const char *, ...) {
+    assert(false);
+    return 0;
+}
 }


### PR DESCRIPTION
This PR adds a patch for a function imported from `libc`, which is not available on WASM. Currently I've just created a stub, which does not actually perform a function, but in the future we can patch this with a proper replacement if need be. Right now it seems to be unused.