### PR TITLE
Fix threading issues on WASM

### DIFF
--- a/src/adapters/parse/magicavoxel.cpp
+++ b/src/adapters/parse/magicavoxel.cpp
@@ -29,7 +29,11 @@ struct MagicavoxelParseUserState {
 };
 
 void initialize_model(GvoxBlitContext *blit_ctx, GvoxAdapterContext *ctx, magicavoxel::Model const &model) {
+#if __wasm32__
+    auto packed_voxel_data = std::vector<uint8_t>();
+#else
     thread_local auto packed_voxel_data = std::vector<uint8_t>();
+#endif
     packed_voxel_data.resize(static_cast<size_t>(model.num_voxels_in_chunk) * 4);
     gvox_input_read(blit_ctx, model.input_offset, packed_voxel_data.size(), packed_voxel_data.data());
     const uint32_t k_stride_x = 1;

--- a/src/utils/patch_wasm.h
+++ b/src/utils/patch_wasm.h
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <stdio.h>
 
 extern "C" {
 uint32_t __imported_wasi_snapshot_preview1_fd_fdstat_get(uint32_t, uint32_t) {
@@ -23,6 +24,10 @@ int32_t __imported_wasi_snapshot_preview1_fd_seek(int32_t, int64_t, int32_t, int
 
 int32_t __imported_wasi_snapshot_preview1_fd_write(int32_t, int32_t, int32_t, int32_t) {
     assert(false);
+    return -1;
+}
+
+int vfprintf(FILE*, const char *, va_list) {
     return -1;
 }
 }


### PR DESCRIPTION
The WASI SDK doesn't handle threads too well - variables marked as `thread_local` actually appear to compile as normal `static` variables on WASM. This was messing up my multithreading code. This PR fixes things.